### PR TITLE
add padding to search box

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -62,7 +62,7 @@
 /* Searchbar: Ensure toolbar height doesn't augment when searchbar is visible */
 #urlbar-container, 
 #search-container {
-	padding-block: 0 !important;
+	padding-block: 2px !important;
 }
 
 /* Searchbar: Make sure the min-height of the input is the same as the popup */


### PR DESCRIPTION
added padding to the search box so it matches the url/search bar

before change:
![before](https://user-images.githubusercontent.com/92043407/145669553-df96ba13-d12c-48ee-977e-8085ec6eac1d.jpg)

after change:
![after](https://user-images.githubusercontent.com/92043407/145669578-c563772c-4ce1-4e51-b537-13709672da1b.jpg) 